### PR TITLE
fix: add database indexes for performance optimization

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -50,6 +50,22 @@ pub async fn create_tables_in_database(pool: &Pool) -> Result<(), async_sqlite::
         .unwrap();
 
         // Note: custom_emojis table removed - we serve emojis directly from static/emojis/ directory
+        
+        // Add indexes for performance optimization
+        // Index on startedAt for feed queries (ORDER BY startedAt DESC)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_status_startedAt ON status(startedAt DESC)",
+            [],
+        )
+        .unwrap();
+        
+        // Composite index for user status queries (WHERE authorDid = ? ORDER BY startedAt DESC)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_status_authorDid_startedAt ON status(authorDid, startedAt DESC)",
+            [],
+        )
+        .unwrap();
+        
         Ok(())
     })
     .await?;


### PR DESCRIPTION
## Summary
Closes #1 

This PR adds two database indexes to significantly improve query performance:
- `idx_status_startedAt`: Optimizes feed queries that `ORDER BY startedAt DESC`
- `idx_status_authorDid_startedAt`: Optimizes user status queries with `WHERE authorDid = ? ORDER BY startedAt DESC`

## Why this matters
Without these indexes, every query has to scan the entire status table and sort it. As the table grows (especially with infinite scrolling now), this becomes increasingly slow. With indexes, the database can directly access the rows in the correct order.

## Impact
- ✅ Feed page loads faster
- ✅ User status lookups are instant
- ✅ Infinite scroll stays responsive as data grows
- ✅ Zero risk - indexes only make things faster, can't break functionality

## Testing
- Compiled successfully ✅
- Feed page still loads all statuses ✅
- API pagination still works ✅
- No changes to application logic, only database optimization

This is the lowest-risk performance improvement we can make.