### PR TITLE
Beautiful timestamps with minute resolution and hover tooltips

### DIFF
--- a/static/timestamps.js
+++ b/static/timestamps.js
@@ -1,0 +1,247 @@
+// Beautiful timestamp formatting with hover tooltips
+// Provides minute-resolution display by default with full timestamp on hover
+
+const TimestampFormatter = {
+    // Format a timestamp with appropriate granularity
+    formatRelative(date, now = new Date()) {
+        const diffMs = now - date;
+        const diffSecs = Math.floor(diffMs / 1000);
+        const diffMins = Math.floor(diffMs / 60000);
+        const diffHours = Math.floor(diffMs / 3600000);
+        const diffDays = Math.floor(diffMs / 86400000);
+        
+        // For very recent times, show "just now"
+        if (diffSecs < 30) {
+            return 'just now';
+        }
+        
+        // Under 1 hour: show minutes
+        if (diffMins < 60) {
+            return `${diffMins}m ago`;
+        }
+        
+        // Under 24 hours: show hours and minutes
+        if (diffHours < 24) {
+            const remainingMins = diffMins % 60;
+            if (remainingMins === 0) {
+                return `${diffHours}h ago`;
+            }
+            return `${diffHours}h ${remainingMins}m ago`;
+        }
+        
+        // Under 7 days: show days and hours
+        if (diffDays < 7) {
+            const remainingHours = diffHours % 24;
+            if (remainingHours === 0) {
+                return `${diffDays}d ago`;
+            }
+            return `${diffDays}d ${remainingHours}h ago`;
+        }
+        
+        // Over a week: show date with time
+        const timeStr = date.toLocaleTimeString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true
+        }).toLowerCase();
+        
+        // If same year, don't show year
+        if (date.getFullYear() === now.getFullYear()) {
+            return date.toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric'
+            }) + ', ' + timeStr;
+        }
+        
+        // Different year: show full date
+        return date.toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric'
+        }) + ', ' + timeStr;
+    },
+    
+    // Format future timestamps (for expiry times)
+    formatFuture(date, now = new Date()) {
+        const diffMs = date - now;
+        const diffSecs = Math.floor(diffMs / 1000);
+        const diffMins = Math.floor(diffMs / 60000);
+        const diffHours = Math.floor(diffMs / 3600000);
+        const diffDays = Math.floor(diffMs / 86400000);
+        
+        if (diffSecs < 60) {
+            return 'expires soon';
+        }
+        
+        if (diffMins < 60) {
+            return `expires in ${diffMins}m`;
+        }
+        
+        if (diffHours < 24) {
+            const remainingMins = diffMins % 60;
+            if (remainingMins === 0) {
+                return `expires in ${diffHours}h`;
+            }
+            return `expires in ${diffHours}h ${remainingMins}m`;
+        }
+        
+        if (diffDays < 7) {
+            const remainingHours = diffHours % 24;
+            if (remainingHours === 0) {
+                return `expires in ${diffDays}d`;
+            }
+            return `expires in ${diffDays}d ${remainingHours}h`;
+        }
+        
+        // Over a week: show date
+        return 'expires ' + date.toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true
+        }).toLowerCase();
+    },
+    
+    // Format for history view (compact but informative)
+    formatCompact(date, now = new Date()) {
+        const diffMs = now - date;
+        const diffMins = Math.floor(diffMs / 60000);
+        const diffHours = Math.floor(diffMs / 3600000);
+        const diffDays = Math.floor(diffMs / 86400000);
+        
+        // Today: show time only
+        if (date.toDateString() === now.toDateString()) {
+            return date.toLocaleTimeString('en-US', {
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+            }).toLowerCase();
+        }
+        
+        // Yesterday: show "yesterday" + time
+        const yesterday = new Date(now);
+        yesterday.setDate(yesterday.getDate() - 1);
+        if (date.toDateString() === yesterday.toDateString()) {
+            return 'yesterday, ' + date.toLocaleTimeString('en-US', {
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+            }).toLowerCase();
+        }
+        
+        // Within 7 days: show day of week + time
+        if (diffDays < 7) {
+            const dayName = date.toLocaleDateString('en-US', { weekday: 'short' }).toLowerCase();
+            const time = date.toLocaleTimeString('en-US', {
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+            }).toLowerCase();
+            return `${dayName}, ${time}`;
+        }
+        
+        // Same year: show month, day, time
+        if (date.getFullYear() === now.getFullYear()) {
+            return date.toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+            }).toLowerCase();
+        }
+        
+        // Different year: show full date
+        return date.toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true
+        }).toLowerCase();
+    },
+    
+    // Get full timestamp for tooltip
+    getFullTimestamp(date) {
+        // Get day of week
+        const dayName = date.toLocaleDateString('en-US', { weekday: 'long' });
+        
+        // Get month and day
+        const monthDay = date.toLocaleDateString('en-US', {
+            month: 'long',
+            day: 'numeric',
+            year: 'numeric'
+        });
+        
+        // Get time with seconds
+        const time = date.toLocaleTimeString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: true
+        });
+        
+        // Get timezone
+        const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const tzAbbr = date.toLocaleTimeString('en-US', {
+            timeZoneName: 'short'
+        }).split(' ').pop();
+        
+        return `${dayName}, ${monthDay} at ${time} ${tzAbbr}`;
+    },
+    
+    // Initialize all timestamps on the page
+    initialize() {
+        const updateTimestamps = () => {
+            const now = new Date();
+            
+            document.querySelectorAll('.local-time').forEach(el => {
+                const timestamp = el.getAttribute('data-timestamp');
+                if (!timestamp) return;
+                
+                const date = new Date(timestamp);
+                const format = el.getAttribute('data-format');
+                const prefix = el.getAttribute('data-prefix');
+                
+                let text = '';
+                
+                // Determine format type
+                if (prefix === 'expires' || prefix === 'clears') {
+                    text = this.formatFuture(date, now);
+                } else if (format === 'compact' || format === 'short') {
+                    text = this.formatCompact(date, now);
+                } else if (prefix === 'since') {
+                    const relativeText = this.formatRelative(date, now);
+                    text = `since ${relativeText}`.replace('since just now', 'just started');
+                } else {
+                    text = this.formatRelative(date, now);
+                }
+                
+                // Update text content
+                el.textContent = text;
+                
+                // Add tooltip with full timestamp
+                const fullTimestamp = this.getFullTimestamp(date);
+                el.setAttribute('title', fullTimestamp);
+                el.style.cursor = 'help';
+                el.style.borderBottom = '1px dotted currentColor';
+                el.style.textDecoration = 'none';
+            });
+        };
+        
+        // Initial update
+        updateTimestamps();
+        
+        // Update every 30 seconds for better granularity
+        setInterval(updateTimestamps, 30000);
+    }
+};
+
+// Auto-initialize when DOM is ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => TimestampFormatter.initialize());
+} else {
+    TimestampFormatter.initialize();
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,9 @@
     <meta property="twitter:title" content="{% block twitter_title %}status{% endblock %}">
     <meta property="twitter:description" content="{% block twitter_description %}like slack status, but decoupled from any platform{% endblock %}">
     <meta property="twitter:image" content="{% block twitter_image %}https://status.zzstoatzz.io/og-image.png{% endblock %}">
+    
+    <!-- Shared Timestamp Formatter -->
+    <script src="/static/timestamps.js"></script>
 </head>
 <body>
     {% block content %}{% endblock %}

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -547,66 +547,7 @@ const toggleTheme = () => {
     }
 };
 
-// Format local times
-const formatLocalTime = () => {
-    document.querySelectorAll('.local-time').forEach(el => {
-        const timestamp = el.getAttribute('data-timestamp');
-        const format = el.getAttribute('data-format');
-        const prefix = el.getAttribute('data-prefix');
-        
-        if (!timestamp) return;
-        
-        const date = new Date(timestamp);
-        const now = new Date();
-        const diffMs = now - date;
-        const diffMins = Math.floor(diffMs / 60000);
-        const diffHours = Math.floor(diffMs / 3600000);
-        const diffDays = Math.floor(diffMs / 86400000);
-        
-        let text = '';
-        
-        if (format === 'relative') {
-            if (diffMins < 1) {
-                text = 'just now';
-            } else if (diffMins < 60) {
-                text = `${diffMins} minute${diffMins !== 1 ? 's' : ''} ago`;
-            } else if (diffHours < 24) {
-                text = `${diffHours} hour${diffHours !== 1 ? 's' : ''} ago`;
-            } else if (diffDays < 7) {
-                text = `${diffDays} day${diffDays !== 1 ? 's' : ''} ago`;
-            } else {
-                text = date.toLocaleDateString();
-            }
-        } else if (prefix === 'expires') {
-            const futureMs = date - now;
-            const futureMins = Math.floor(futureMs / 60000);
-            const futureHours = Math.floor(futureMs / 3600000);
-            const futureDays = Math.floor(futureMs / 86400000);
-            
-            if (futureMins < 1) {
-                text = 'expires soon';
-            } else if (futureMins < 60) {
-                text = `expires in ${futureMins} minute${futureMins !== 1 ? 's' : ''}`;
-            } else if (futureHours < 24) {
-                text = `expires in ${futureHours} hour${futureHours !== 1 ? 's' : ''}`;
-            } else {
-                text = `expires in ${futureDays} day${futureDays !== 1 ? 's' : ''}`;
-            }
-        } else {
-            // Default format
-            const options = { 
-                month: 'short', 
-                day: 'numeric',
-                hour: 'numeric',
-                minute: '2-digit',
-                hour12: true
-            };
-            text = date.toLocaleString('en-US', options).toLowerCase();
-        }
-        
-        el.textContent = text;
-    });
-};
+// Timestamp formatting is handled by /static/timestamps.js
 
 // Infinite scroll variables
 let isLoading = false;
@@ -647,48 +588,13 @@ const loadMoreStatuses = async () => {
                 emojiHtml = status.status;
             }
             
-            // Format the timestamp
-            const date = new Date(status.started_at);
-            const now = new Date();
-            const diffMs = now - date;
-            const diffMins = Math.floor(diffMs / 60000);
-            const diffHours = Math.floor(diffMs / 3600000);
-            const diffDays = Math.floor(diffMs / 86400000);
-            
-            let timeText = '';
-            if (diffMins < 1) {
-                timeText = 'just now';
-            } else if (diffMins < 60) {
-                timeText = `${diffMins} minute${diffMins !== 1 ? 's' : ''} ago`;
-            } else if (diffHours < 24) {
-                timeText = `${diffHours} hour${diffHours !== 1 ? 's' : ''} ago`;
-            } else if (diffDays < 7) {
-                timeText = `${diffDays} day${diffDays !== 1 ? 's' : ''} ago`;
-            } else {
-                timeText = date.toLocaleDateString();
-            }
-            
-            // Calculate expiry if present
+            // Build expiry HTML if present
             let expiryHtml = '';
             if (status.expires_at) {
                 const expiryDate = new Date(status.expires_at);
+                const now = new Date();
                 if (expiryDate > now) {
-                    const futureMs = expiryDate - now;
-                    const futureMins = Math.floor(futureMs / 60000);
-                    const futureHours = Math.floor(futureMs / 3600000);
-                    const futureDays = Math.floor(futureMs / 86400000);
-                    
-                    let expiryText = '';
-                    if (futureMins < 1) {
-                        expiryText = 'expires soon';
-                    } else if (futureMins < 60) {
-                        expiryText = `expires in ${futureMins} minute${futureMins !== 1 ? 's' : ''}`;
-                    } else if (futureHours < 24) {
-                        expiryText = `expires in ${futureHours} hour${futureHours !== 1 ? 's' : ''}`;
-                    } else {
-                        expiryText = `expires in ${futureDays} day${futureDays !== 1 ? 's' : ''}`;
-                    }
-                    expiryHtml = ` • ${expiryText}`;
+                    expiryHtml = ` • <span class="local-time" data-timestamp="${status.expires_at}" data-prefix="expires"></span>`;
                 } else {
                     expiryHtml = ' • expired';
                 }
@@ -705,13 +611,18 @@ const loadMoreStatuses = async () => {
                         ${status.text ? `<span class="status-text">${status.text}</span>` : ''}
                     </div>
                     <div class="status-meta">
-                        <span>${timeText}</span>${expiryHtml}
+                        <span class="local-time" data-timestamp="${status.started_at}" data-format="relative"></span>${expiryHtml}
                     </div>
                 </div>
             `;
             
             statusList.appendChild(statusItem);
         });
+        
+        // Re-initialize timestamps for newly added elements
+        if (typeof TimestampFormatter !== 'undefined') {
+            TimestampFormatter.initialize();
+        }
         
         offset += newStatuses.length;
         loadingIndicator.style.display = 'none';
@@ -738,7 +649,7 @@ const checkScroll = () => {
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', () => {
     initTheme();
-    formatLocalTime();
+    // Timestamps are auto-initialized by timestamps.js
     
     // Theme toggle
     const themeToggle = document.getElementById('theme-toggle');
@@ -757,8 +668,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }, 100);
     
-    // Update times every minute
-    setInterval(formatLocalTime, 60000);
+    // Timestamps auto-update via timestamps.js
     
     // Admin hide button functionality
     document.querySelectorAll('.hide-button').forEach(button => {

--- a/templates/status.html
+++ b/templates/status.html
@@ -206,7 +206,7 @@
                     {% if status.text.is_some() %}
                     <span class="history-text">{{ status.text.as_ref().unwrap() }}</span>
                     {% endif %}
-                    <span class="history-time local-time" data-timestamp="{{ status.started_at.to_rfc3339() }}" data-format="short"></span>
+                    <span class="history-time local-time" data-timestamp="{{ status.started_at.to_rfc3339() }}" data-format="compact"></span>
                 </div>
                 {% if is_owner %}
                 <button type="button" class="history-delete" data-uri="{{ status.uri }}" title="Delete this status">
@@ -1248,65 +1248,11 @@ const emojiData = {
 };
 
 // Initialize on page load
-// Format local times
-const formatLocalTimes = () => {
-    document.querySelectorAll('.local-time').forEach(el => {
-        const timestamp = el.dataset.timestamp;
-        const prefix = el.dataset.prefix;
-        const format = el.dataset.format;
-        
-        if (timestamp) {
-            const date = new Date(timestamp);
-            const now = new Date();
-            const isToday = date.toDateString() === now.toDateString();
-            
-            let formatted;
-            if (format === 'short') {
-                // For history items
-                if (isToday) {
-                    formatted = date.toLocaleTimeString('en-US', { 
-                        hour: 'numeric', 
-                        minute: '2-digit',
-                        hour12: true 
-                    }).toLowerCase();
-                } else {
-                    formatted = date.toLocaleDateString('en-US', { 
-                        month: 'short', 
-                        day: 'numeric' 
-                    });
-                }
-            } else {
-                // For current status
-                if (isToday) {
-                    formatted = date.toLocaleTimeString('en-US', { 
-                        hour: 'numeric', 
-                        minute: '2-digit',
-                        hour12: true 
-                    }).toLowerCase();
-                } else {
-                    formatted = date.toLocaleDateString('en-US', { 
-                        month: 'short', 
-                        day: 'numeric' 
-                    }) + ', ' + date.toLocaleTimeString('en-US', { 
-                        hour: 'numeric', 
-                        minute: '2-digit',
-                        hour12: true 
-                    }).toLowerCase();
-                }
-                
-                if (prefix) {
-                    formatted = prefix + ' ' + formatted;
-                }
-            }
-            
-            el.textContent = formatted;
-        }
-    });
-};
+// Timestamp formatting is handled by /static/timestamps.js
 
 document.addEventListener('DOMContentLoaded', () => {
     initTheme();
-    formatLocalTimes();
+    // Timestamps are auto-initialized by timestamps.js
     
     // Theme toggle
     const themeToggle = document.getElementById('theme-toggle');


### PR DESCRIPTION
## Summary
- Unified timestamp formatting across the entire site with minute-level granularity
- Added hover tooltips showing full timestamp details
- Improved readability with smart relative formatting

## Changes
- Created `/static/timestamps.js` - shared timestamp formatter module
- Replaced all local timestamp formatting with the unified system
- Added minute resolution (e.g., "5h 23m ago" instead of "5 hours ago")
- Hover shows full timestamp like GitHub (e.g., "Wednesday, September 3, 2025 at 12:15:42 AM PDT")
- Smart formatting for different contexts:
  - Recent: "just now", "5m ago"
  - Hours: "2h 15m ago"
  - Days: "3d 5h ago"
  - This week: "wed, 3:45 pm"
  - Older: "sep 2, 11:45 pm"
- Visual indicator (dotted underline) shows timestamps are hoverable
- Auto-updates every 30 seconds for better accuracy

## Test Plan
- [x] Visit status page - verify current status shows minute resolution
- [x] Check status history - verify compact format with hover tooltips
- [x] Visit global feed - verify all timestamps show proper format
- [x] Test infinite scroll - verify new items get formatted correctly
- [x] Hover over any timestamp - verify full timestamp tooltip appears
- [x] Wait 30 seconds - verify timestamps update automatically

🤖 Generated with [Claude Code](https://claude.ai/code)