### PR TITLE
Fix: Limit timestamp hover area to text only

### DIFF
--- a/static/timestamps.js
+++ b/static/timestamps.js
@@ -228,8 +228,10 @@ const TimestampFormatter = {
                 el.style.cursor = 'help';
                 el.style.borderBottom = '1px dotted currentColor';
                 el.style.textDecoration = 'none';
-                el.style.display = 'inline';
+                el.style.display = 'inline-block';
                 el.style.lineHeight = '1.2';
+                el.style.alignSelf = 'flex-start';
+                el.style.width = 'auto';
             });
         };
         

--- a/static/timestamps.js
+++ b/static/timestamps.js
@@ -228,6 +228,8 @@ const TimestampFormatter = {
                 el.style.cursor = 'help';
                 el.style.borderBottom = '1px dotted currentColor';
                 el.style.textDecoration = 'none';
+                el.style.display = 'inline';
+                el.style.lineHeight = '1.2';
             });
         };
         


### PR DESCRIPTION
## Problem
After merging #9, the timestamp hover behavior was triggering across the entire horizontal width of the parent container, not just when hovering over the timestamp text itself.

## Solution
- Set `display: inline` on timestamp elements to prevent them from expanding to full container width
- Added `line-height: 1.2` for better visual consistency
- Now the tooltip and hover indicators only appear when hovering directly over the timestamp text

## Testing
- [x] Visit status page - hover only works on timestamp text
- [x] Visit feed page - hover only works on timestamp text  
- [x] Check history items - hover only works on timestamp text
- [x] Verify tooltip still shows full timestamp when hovering over text

🤖 Generated with [Claude Code](https://claude.ai/code)