### PR TITLE
fix: ensure infinite scroll works when switching to following feed first

### DIFF
--- a/templates/feed.html
+++ b/templates/feed.html
@@ -647,6 +647,16 @@ const fetchFollowing = async () => {
     }
 };
 
+// Check if we need to load more content after filtering
+const checkNeedMoreContent = () => {
+    // Check if filtered content fills the viewport
+    setTimeout(() => {
+        if (document.documentElement.scrollHeight <= window.innerHeight && hasMore && !isLoading) {
+            loadMoreStatuses();
+        }
+    }, 50); // Small delay to ensure layout is updated
+};
+
 // Apply following filter to existing statuses
 const applyFollowingFilter = (active) => {
     const statusItems = document.querySelectorAll('.status-item');
@@ -665,6 +675,11 @@ const applyFollowingFilter = (active) => {
             }
         }
     });
+    
+    // After filtering, check if we need more content
+    if (active) {
+        checkNeedMoreContent();
+    }
 };
 
 // Infinite scroll variables


### PR DESCRIPTION
## Summary
Fixes infinite scroll issue when switching to following feed before scrolling.

## Problem
When users switch to following feed first (before scrolling), the filter hides non-following posts but doesn't trigger infinite scroll to load more content. This results in seeing fewer posts from people they follow.

## Solution
- Add `checkNeedMoreContent()` function that checks if filtered content fills viewport
- Call this function after applying the following filter
- Automatically loads more content if the filtered view doesn't fill the screen
- Uses a small delay to ensure layout is updated before checking

## Test Plan
- [x] Switch to following feed before scrolling
- [x] Verify that more content loads automatically if viewport isn't full  
- [x] Ensure normal scrolling still works after the fix
- [x] Verify cached following list still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)