### PR TITLE
Include user's own posts in following feed

### DIFF
--- a/templates/feed.html
+++ b/templates/feed.html
@@ -667,8 +667,8 @@ const applyFollowingFilter = (active) => {
             item.style.display = '';
         } else {
             const authorDid = item.getAttribute('data-did');
-            // Check if this author is in our following list
-            if (followingDids.includes(authorDid)) {
+            // Check if this author is in our following list OR is the current user
+            if (followingDids.includes(authorDid) || authorDid === currentUserDid) {
                 item.style.display = '';
             } else {
                 item.style.display = 'none';
@@ -690,6 +690,8 @@ let hasMore = true;
 // Following filter variables
 let followingDids = null;
 let filterActive = false;
+// Store current user's DID to include their own posts in following feed
+const currentUserDid = {% if let Some(Profile {did, display_name}) = profile %}"{{ did }}"{% else %}null{% endif %};
 
 // Load more statuses
 const loadMoreStatuses = async () => {


### PR DESCRIPTION
## Summary
Following feeds on Twitter-style apps include the user's own posts even though it doesn't technically match the meaning of "following". This PR updates the following filter to include the current user's posts.

Fixes #22

## Changes
- Added `currentUserDid` variable to track the logged-in user's DID
- Updated `applyFollowingFilter` function to show posts from:
  - All accounts the user follows
  - The user's own posts
- User's posts appear chronologically mixed with followed accounts' posts

## Test plan
- [x] Start the app locally with `cargo run`
- [x] Log in to your account
- [x] Navigate to /feed
- [x] Toggle the "Following" filter on
- [x] Verify your own posts appear in the following feed
- [x] Verify infinite scroll still works correctly
- [x] Verify the filter can be toggled on/off smoothly

## Behavior
Now matches Twitter/X where users see their own posts interspersed in their following timeline.

🤖 Generated with [Claude Code](https://claude.ai/code)