### PR TITLE
Remove hard-coded emoji list; front-end now loads from CDN

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,38 +107,7 @@ async fn client_metadata(config: web::Data<config::Config>) -> Result<HttpRespon
         .body(metadata.to_string()))
 }
 
-/// All the available emoji status options
-const STATUS_OPTIONS: [&str; 29] = [
-    "👍",
-    "👎",
-    "💙",
-    "🥹",
-    "😧",
-    "😤",
-    "🙃",
-    "😉",
-    "😎",
-    "🤓",
-    "🤨",
-    "🥳",
-    "😭",
-    "😤",
-    "🤯",
-    "🫡",
-    "💀",
-    "✊",
-    "🤘",
-    "👀",
-    "🧠",
-    "👩‍💻",
-    "🧑‍💻",
-    "🥷",
-    "🧌",
-    "🦋",
-    "🚀",
-    "🥔",
-    "🦀",
-];
+// Removed STATUS_OPTIONS: emojis are now loaded client-side from CDN
 
 /// TS version https://github.com/bluesky-social/statusphere-example-app/blob/e4721616df50cd317c198f4c00a4818d5626d4ce/src/routes.ts#L71
 /// OAuth callback endpoint to complete session creation
@@ -346,7 +315,6 @@ async fn home(
             let html = StatusTemplate {
                 title: "your status",
                 handle,
-                status_options: &STATUS_OPTIONS,
                 current_status,
                 history,
                 is_owner: true, // They're viewing their own status
@@ -403,7 +371,6 @@ async fn home(
             let html = StatusTemplate {
                 title: "nate's status",
                 handle: OWNER_HANDLE.to_string(),
-                status_options: &STATUS_OPTIONS,
                 current_status,
                 history,
                 is_owner: false, // Visitor viewing owner's status
@@ -493,7 +460,6 @@ async fn user_status_page(
     let html = StatusTemplate {
         title: &format!("@{} status", handle),
         handle: handle.clone(),
-        status_options: &STATUS_OPTIONS,
         current_status,
         history,
         is_owner,

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -32,8 +32,6 @@ pub struct StatusTemplate<'a> {
     #[allow(dead_code)]
     pub title: &'a str,
     pub handle: String,
-    #[allow(dead_code)]
-    pub status_options: &'a [&'a str],
     pub current_status: Option<StatusFromDb>,
     pub history: Vec<StatusFromDb>,
     pub is_owner: bool,


### PR DESCRIPTION
Removes obsolete backend constant and template field.\n\n- Drop STATUS_OPTIONS and stop passing it to templates.\n- Front end fetches full emoji set from CDN via static/emoji-data.js.\n- No behavior change; custom emojis still served from /emojis and listed via /api/custom-emojis.\n- cargo build and cargo test pass locally.