### PR TITLE
feat: use cleaner OAuth metadata URL path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,12 +86,12 @@ fn is_admin(did: &str) -> bool {
 }
 
 /// OAuth client metadata endpoint for production
-#[get("/client-metadata.json")]
+#[get("/oauth-client-metadata.json")]
 async fn client_metadata(config: web::Data<config::Config>) -> Result<HttpResponse> {
     let public_url = config.oauth_redirect_base.clone();
 
     let metadata = serde_json::json!({
-        "client_id": format!("{}/client-metadata.json", public_url),
+        "client_id": format!("{}/oauth-client-metadata.json", public_url),
         "client_name": "Status Sphere",
         "client_uri": public_url.clone(),
         "redirect_uris": [format!("{}/oauth/callback", public_url)],
@@ -1445,7 +1445,7 @@ async fn main() -> std::io::Result<()> {
 
         let oauth_config = OAuthClientConfig {
             client_metadata: AtprotoClientMetadata {
-                client_id: format!("{}/client-metadata.json", config.oauth_redirect_base),
+                client_id: format!("{}/oauth-client-metadata.json", config.oauth_redirect_base),
                 client_uri: Some(config.oauth_redirect_base.clone()),
                 redirect_uris: vec![format!("{}/oauth/callback", config.oauth_redirect_base)],
                 token_endpoint_auth_method: AuthMethod::None,


### PR DESCRIPTION
## Summary
- Changed OAuth metadata endpoint from `/client-metadata.json` to `/oauth-client-metadata.json`
- Makes the authorization screen display cleaner and less suspicious

## Context
Based on community feedback in the AT Protocol discussion, using `/oauth-client-metadata.json` instead of `/client-metadata.json` results in a cleaner display on the OAuth authorization screen. The domain name appears more prominently without the long URL string.

## Changes
- Updated endpoint route from `/client-metadata.json` to `/oauth-client-metadata.json`
- Updated client_id references in both the metadata response and OAuth configuration

## Impact
- No breaking changes for existing users
- OAuth flow continues to work the same way
- Authorization screen will look more professional and trustworthy

## References
- Discussion: https://bsky.app/profile/dame.is/post/3lxdfrg574k2e

🤖 Generated with [Claude Code](https://claude.ai/code)