### PR TITLE
Add hover tooltips to show emoji names

### DIFF
--- a/templates/feed.html
+++ b/templates/feed.html
@@ -111,10 +111,10 @@
                     <span class="status-emoji">
                         {% if status.status.starts_with("custom:") %}
                             {% let emoji_name = status.status.strip_prefix("custom:").unwrap() %}
-                            <img src="/emojis/{{emoji_name}}.png" alt="{{emoji_name}}" class="custom-emoji-display"
+                            <img src="/emojis/{{emoji_name}}.png" alt="{{emoji_name}}" title="{{emoji_name}}" class="custom-emoji-display"
                                  onerror="this.onerror=null; this.src='/emojis/{{emoji_name}}.gif';">
                         {% else %}
-                            {{status.status}}
+                            <span title="{{status.status}}">{{status.status}}</span>
                         {% endif %}
                     </span>
                     <div class="status-content">
@@ -909,9 +909,9 @@ const loadMoreStatuses = async () => {
             let emojiHtml = '';
             if (status.status.startsWith('custom:')) {
                 const emojiName = status.status.substring(7);
-                emojiHtml = `<img src="/emojis/${emojiName}.png" alt="${emojiName}" class="custom-emoji-display" onerror="this.onerror=null; this.src='/emojis/${emojiName}.gif';">`;
+                emojiHtml = `<img src="/emojis/${emojiName}.png" alt="${emojiName}" title="${emojiName}" class="custom-emoji-display" onerror="this.onerror=null; this.src='/emojis/${emojiName}.gif';">`;
             } else {
-                emojiHtml = status.status;
+                emojiHtml = `<span title="${status.status}">${status.status}</span>`;
             }
             
             // Build expiry HTML if present

--- a/templates/status.html
+++ b/templates/status.html
@@ -81,10 +81,10 @@
                 <span class="status-emoji">
                     {% if current.status.starts_with("custom:") %}
                         {% let emoji_name = current.status.strip_prefix("custom:").unwrap() %}
-                        <img src="/emojis/{{emoji_name}}.png" alt="{{emoji_name}}" class="custom-emoji-display"
+                        <img src="/emojis/{{emoji_name}}.png" alt="{{emoji_name}}" title="{{emoji_name}}" class="custom-emoji-display"
                              onerror="this.onerror=null; this.src='/emojis/{{emoji_name}}.gif';">
                     {% else %}
-                        {{ current.status }}
+                        <span title="{{ current.status }}">{{ current.status }}</span>
                     {% endif %}
                 </span>
                 <div class="status-content">
@@ -118,13 +118,13 @@
                                 {% if let Some(current) = current_status.as_ref() %}
                                     {% if current.status.starts_with("custom:") %}
                                         {% let emoji_name = current.status.strip_prefix("custom:").unwrap() %}
-                                        <img src="/emojis/{{emoji_name}}.png" alt="{{emoji_name}}" 
+                                        <img src="/emojis/{{emoji_name}}.png" alt="{{emoji_name}}" title="{{emoji_name}}"
                                              onerror="this.onerror=null; this.src='/emojis/{{emoji_name}}.gif';">
                                     {% else %}
-                                        {{ current.status }}
+                                        <span title="{{ current.status }}">{{ current.status }}</span>
                                     {% endif %}
                                 {% else %}
-                                    😊
+                                    <span title="happy">😊</span>
                                 {% endif %}
                             </span>
                         </button>
@@ -227,10 +227,10 @@
                 <span class="history-emoji">
                     {% if status.status.starts_with("custom:") %}
                         {% let emoji_name = status.status.strip_prefix("custom:").unwrap() %}
-                        <img src="/emojis/{{emoji_name}}.png" alt="{{emoji_name}}" class="custom-emoji-display"
+                        <img src="/emojis/{{emoji_name}}.png" alt="{{emoji_name}}" title="{{emoji_name}}" class="custom-emoji-display"
                              onerror="this.onerror=null; this.src='/emojis/{{emoji_name}}.gif';">
                     {% else %}
-                        {{ status.status }}
+                        <span title="{{ status.status }}">{{ status.status }}</span>
                     {% endif %}
                 </span>
                 <div class="history-content">


### PR DESCRIPTION
## Summary
- Adds hover tooltips to all emojis in the feed and status displays
- Shows the emoji name when hovering, making it easier to discover emoji codes
- Consistent with the existing behavior in the emoji selector

## Changes
- Added `title` attributes to custom emoji `<img>` tags
- Wrapped standard emojis in `<span>` elements with `title` attributes  
- Updated both server-rendered templates and client-side JavaScript

## Test plan
- [x] Hover over custom emojis in the feed - tooltip shows emoji name
- [x] Hover over standard emojis in the feed - tooltip shows emoji character
- [x] Hover over emojis in status history - tooltips work correctly
- [x] Dynamically loaded statuses (infinite scroll) show tooltips
- [x] No visual changes to the UI

🤖 Generated with [Claude Code](https://claude.ai/code)