### PR TITLE
Fix display name fallback and mobile spacing issues

### DIFF
--- a/src/api/status.rs
+++ b/src/api/status.rs
@@ -565,6 +565,7 @@ pub async fn feed(
                                 let profile_data = Profile {
                                     did: profile.did.to_string(),
                                     display_name: profile.display_name.clone(),
+                                    handle: Some(profile.handle.to_string()),
                                 };
                                 Some(profile_data)
                             }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct Profile {
     pub did: String,
     pub display_name: Option<String>,
+    pub handle: Option<String>,
 }
 
 #[derive(Template)]

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -7,7 +7,7 @@
         <header class="header">
             <div class="feed-title-wrapper">
                 <h1 id="feed-title">global feed</h1>
-                {% if let Some(Profile {did, display_name}) = profile %}
+                {% if let Some(p) = &profile %}
                 <label class="feed-toggle" for="feed-toggle-input">
                     <input type="checkbox" id="feed-toggle-input" />
                     <span class="toggle-slider"></span>
@@ -21,7 +21,7 @@
                         <polyline points="9 22 9 12 15 12 15 22"></polyline>
                     </svg>
                 </a>
-                {% if let Some(Profile {did, display_name}) = profile %}
+                {% if let Some(p) = &profile %}
                 <button class="settings-toggle" id="settings-toggle" aria-label="Settings">
                     <img src="https://api.iconify.design/lucide:settings.svg?color=%23888" width="20" height="20" alt="Settings">
                 </button>
@@ -47,7 +47,7 @@
         </header>
         
         <!-- Simple Settings (logged in users only) -->
-        {% if let Some(Profile {did, display_name}) = profile %}
+        {% if let Some(p) = &profile %}
         <div class="simple-settings hidden" id="simple-settings">
             <div class="settings-row">
                 <label>font</label>
@@ -74,10 +74,10 @@
         {% endif %}
 
         <!-- Session Info -->
-        {% if let Some(Profile {did, display_name}) = profile %}
+        {% if let Some(p) = &profile %}
         <div class="session-card">
             <div class="session-info">
-                <span>logged in as <strong>{% if let Some(name) = display_name %}{{ name }}{% else %}{{ did }}{% endif %}</strong></span>
+                <span>logged in as <strong>{% if let Some(name) = &p.display_name %}{{ name }}{% else %}{% if let Some(h) = &p.handle %}{{ h }}{% else %}{{ p.did }}{% endif %}{% endif %}</strong></span>
                 <div class="session-actions">
                     <a href="/" class="button button-primary">your status</a>
                     <form action="/logout" method="get" style="display: inline;">
@@ -713,8 +713,24 @@ body {
         padding: 1rem;
     }
     
+    .header {
+        flex-direction: column;
+        gap: 1rem;
+        align-items: stretch;
+    }
+    
     .header h1 {
         font-size: 1.25rem;
+    }
+    
+    .feed-title-wrapper {
+        justify-content: space-between;
+        width: 100%;
+    }
+    
+    .header-actions {
+        justify-content: flex-end;
+        width: 100%;
     }
     
     .status-item {
@@ -877,7 +893,7 @@ let hasMore = true;
 let followingDids = null;
 let filterActive = false;
 // Store current user's DID to include their own posts in following feed
-const currentUserDid = {% if let Some(Profile {did, display_name}) = profile %}"{{ did }}"{% else %}null{% endif %};
+const currentUserDid = {% if let Some(p) = &profile %}"{{ p.did }}"{% else %}null{% endif %};
 
 // Load more statuses
 const loadMoreStatuses = async () => {


### PR DESCRIPTION
## Summary
- Fixed display name fallback to use handle instead of DID when display name is blank
- Improved mobile layout spacing to separate feed toggle from home button

## Test plan
- [x] When a user has no display name set, their handle is displayed instead of their DID
- [x] On mobile devices, the feed toggle and home button are properly spaced apart for better usability
- [x] All existing functionality continues to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)