### PR TITLE
Fix empty display_name fallback to handle

### DIFF
--- a/templates/feed.html
+++ b/templates/feed.html
@@ -77,7 +77,7 @@
         {% if let Some(p) = &profile %}
         <div class="session-card">
             <div class="session-info">
-                <span>logged in as <strong>{% if let Some(name) = &p.display_name %}{{ name }}{% else %}{% if let Some(h) = &p.handle %}{{ h }}{% else %}{{ p.did }}{% endif %}{% endif %}</strong></span>
+                <span>logged in as <strong>{% if let Some(name) = &p.display_name %}{% if !name.is_empty() %}{{ name }}{% else %}{% if let Some(h) = &p.handle %}{{ h }}{% else %}{{ p.did }}{% endif %}{% endif %}{% else %}{% if let Some(h) = &p.handle %}{{ h }}{% else %}{{ p.did }}{% endif %}{% endif %}</strong></span>
                 <div class="session-actions">
                     <a href="/" class="button button-primary">your status</a>
                     <form action="/logout" method="get" style="display: inline;">


### PR DESCRIPTION
## Summary
Fixed the issue where users with empty display_name strings were showing blank instead of their handle.

## The Problem
- When `display_name` is `Some("")` (empty string), the template was showing the empty string
- It only fell back to handle when `display_name` was `None`
- Users like `zzstoatzzdevlog.bsky.social` with blank display names appeared as "logged in as" with nothing after it

## The Fix
- Added `!name.is_empty()` check in the template
- Now properly falls back to handle when display_name exists but is empty

## Test plan
- [x] Tested logic with isolated Rust program confirming the bug and fix
- [x] Built successfully with the fix
- [ ] Users with empty display_name should now show their handle
- [ ] Users with actual display_name continue to show it

🤖 Generated with [Claude Code](https://claude.ai/code)