### PR TITLE
fix: refine aesthetic details for better UX

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -292,7 +292,7 @@ body {
     --text-tertiary: #adb5bd;
     --border-color: #e9ecef;
     --accent: #4a9eff;
-    --accent-hover: #3a8eee;
+    --accent-hover: color-mix(in srgb, var(--accent) 85%, black);
     --danger: #dc3545;
     --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
     --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
@@ -394,11 +394,11 @@ body {
 
 .handle-link:hover {
     color: var(--accent);
-    text-shadow: 0 0 20px rgba(74, 158, 255, 0.3);
+    text-shadow: 0 0 12px var(--accent);
 }
 
 .handle-link:hover::before {
-    opacity: 0.3;
+    opacity: 0;
 }
 
 .nav-button {
@@ -636,8 +636,8 @@ body {
         filter: drop-shadow(0 0 0 transparent);
     }
     50% {
-        transform: scale(1.02);
-        filter: drop-shadow(0 0 12px var(--accent));
+        transform: scale(1.018);
+        filter: drop-shadow(0 0 10px var(--accent));
     }
 }
 


### PR DESCRIPTION
## Summary
- Removed bounding rectangle glow effect on handle hover - now only the text glows
- Made set button hover color dynamic based on accent color instead of hardcoded blue
- Reduced pulsating glow intensity on active status emoji by ~10%

## Changes
1. **Handle hover effect**: Removed the ::before pseudo-element opacity on hover and reduced text-shadow blur
2. **Dynamic accent hover**: Changed `--accent-hover` to use `color-mix()` to darken the accent color by 15%
3. **Pulsating glow**: Reduced scale from 1.02 to 1.018 and glow from 12px to 10px

## Test Plan
- [x] Hover over handle text - should see subtle text-only glow
- [x] Change accent color and hover set button - should use darker shade of accent
- [x] View active status emoji - pulsating should be more subtle