### PR TITLE
Reduce emoji pulse + Markdown links in status text

### DIFF
--- a/static/markdown.js
+++ b/static/markdown.js
@@ -1,0 +1,57 @@
+// Lightweight markdown link renderer for status text
+// Converts [text](url) into <a href> with basic sanitization
+(function () {
+  const MD_LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function normalizeUrl(url) {
+    let u = url.trim();
+    // If no scheme and looks like a domain, prefix with https://
+    if (!/^([a-z]+:)?\/\//i.test(u)) {
+      u = 'https://' + u;
+    }
+    try {
+      const parsed = new URL(u);
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+        return parsed.toString();
+      }
+      return null; // disallow other protocols
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function linkifyMarkdown(text) {
+    return text.replace(MD_LINK_RE, (_m, label, url) => {
+      const safeUrl = normalizeUrl(url);
+      const safeLabel = escapeHtml(label);
+      if (!safeUrl) return `[${safeLabel}](${escapeHtml(url)})`;
+      return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer nofollow">${safeLabel}</a>`;
+    });
+  }
+
+  function renderMarkdownLinksIn(root) {
+    const scope = root || document;
+    const nodes = scope.querySelectorAll('.status-text:not([data-md-rendered]), .history-text:not([data-md-rendered])');
+    nodes.forEach((el) => {
+      const original = el.textContent || '';
+      const rendered = linkifyMarkdown(original);
+      if (rendered !== original) {
+        el.innerHTML = rendered;
+      }
+      el.setAttribute('data-md-rendered', 'true');
+    });
+  }
+
+  // Expose globally
+  window.renderMarkdownLinksIn = renderMarkdownLinksIn;
+})();
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,6 +28,8 @@
     
     <!-- Shared Settings Module -->
     <script src="/static/settings.js"></script>
+    <!-- Markdown link renderer for statuses -->
+    <script src="/static/markdown.js"></script>
     
     <!-- Apply User Settings -->
     <script>
@@ -184,6 +186,14 @@
                     // Open in new tab
                     window.open(issueUrl, '_blank');
                 });
+            }
+        });
+    </script>
+    <script>
+        // Render markdown links in any status/history text on load
+        document.addEventListener('DOMContentLoaded', function () {
+            if (window.renderMarkdownLinksIn) {
+                window.renderMarkdownLinksIn(document);
             }
         });
     </script>

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -655,6 +655,12 @@ body {
     color: var(--text-primary);
 }
 
+.status-text a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
 .status-meta {
     font-size: 0.875rem;
     color: var(--text-tertiary);
@@ -950,6 +956,10 @@ const loadMoreStatuses = async () => {
             `;
             
             statusList.appendChild(statusItem);
+            // Render markdown links in the newly added item
+            if (window.renderMarkdownLinksIn) {
+                window.renderMarkdownLinksIn(statusItem);
+            }
         });
         
         // Re-initialize timestamps for newly added elements

--- a/templates/status.html
+++ b/templates/status.html
@@ -636,8 +636,8 @@ body {
         filter: drop-shadow(0 0 0 transparent);
     }
     50% {
-        transform: scale(1.018);
-        filter: drop-shadow(0 0 10px var(--accent));
+        transform: scale(1.01);
+        filter: drop-shadow(0 0 6px var(--accent));
     }
 }
 
@@ -674,6 +674,12 @@ body {
     font-size: 1.25rem;
     color: var(--text-primary);
     margin: 0;
+}
+
+.status-text a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
 }
 
 .no-status .status-text {
@@ -1070,6 +1076,12 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.history-text a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
 }
 
 .history-time {


### PR DESCRIPTION
- Reduce current emoji subtle pulse (scale 1.01, 6px glow)
- Add client-side Markdown [text](url) rendering for status text across pages
- Style links to match accent and underline
- Apply rendering to server-rendered content on load and newly loaded feed items

Impacts:
- templates/status.html (CSS tweaks + link style)
- templates/feed.html (link style + render new items)
- templates/base.html (include markdown.js + init on load)
- static/markdown.js (new: safe markdown link renderer)