### PR TITLE
Implement webhook-based Slack status synchronization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ async-trait = "0.1.88"
 rand = "0.8"
 reqwest = { version = "0.12", features = ["json"] }
 once_cell = "1.19"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+uuid = { version = "1.0", features = ["v4"] }
 
 [build-dependencies]
 askama = "0.13"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod preferences;
 pub mod status;
+pub mod webhooks;
 
 pub use auth::OAuthClientType;
 pub use status::HandleResolver;
@@ -20,6 +21,7 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         .service(status::home)
         .service(status::user_status_page)
         .service(status::feed)
+        .service(status::webhook_settings)
         // Status JSON API routes
         .service(status::owner_status_json)
         .service(status::user_status_json)
@@ -37,5 +39,11 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         .service(status::hide_status)
         // Preferences routes
         .service(preferences::get_preferences)
-        .service(preferences::save_preferences);
+        .service(preferences::save_preferences)
+        // Webhook routes
+        .service(webhooks::get_webhook_config)
+        .service(webhooks::configure_webhook)
+        .service(webhooks::test_webhook)
+        .service(webhooks::get_webhook_deliveries)
+        .service(webhooks::delete_webhook);
 }

--- a/src/api/webhooks.rs
+++ b/src/api/webhooks.rs
@@ -5,7 +5,10 @@ use async_sqlite::Pool;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
-use std::{sync::Arc, time::{SystemTime, UNIX_EPOCH}};
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 use uuid::Uuid;
 
 type HmacSha256 = Hmac<Sha256>;
@@ -93,8 +96,9 @@ impl WebhookEvent {
 
 /// Generate HMAC signature for webhook payload
 pub fn generate_signature(secret: &str, timestamp: i64, payload: &str) -> String {
-    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC can take key of any size");
-    let message = format!("v0:{}:{}", timestamp, payload);
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .expect("HMAC can take key of any size");
+    let message = format!("v1:{}:{}", timestamp, payload);
     mac.update(message.as_bytes());
     let result = mac.finalize();
     format!("v1={}", hex::encode(result.into_bytes()))

--- a/src/api/webhooks.rs
+++ b/src/api/webhooks.rs
@@ -1,0 +1,434 @@
+use crate::db::{WebhookConfig, WebhookDelivery};
+use actix_session::Session;
+use actix_web::{get, post, web, HttpResponse, Result};
+use async_sqlite::Pool;
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use std::{sync::Arc, time::{SystemTime, UNIX_EPOCH}};
+use uuid::Uuid;
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Serialize, Deserialize)]
+pub struct WebhookConfigRequest {
+    pub webhook_url: String,
+    pub webhook_secret: Option<String>, // If None, we'll generate one
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct WebhookConfigResponse {
+    pub id: i64,
+    pub webhook_url: String,
+    pub webhook_secret: String,
+    pub enabled: bool,
+    pub last_delivery_at: Option<i64>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct WebhookTestRequest {
+    pub webhook_url: String,
+    pub webhook_secret: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct WebhookEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub user_did: String,
+    pub handle: String,
+    pub emoji: String,
+    pub text: Option<String>,
+    pub expires_at: Option<String>,
+    pub status_uri: String,
+    pub timestamp: String,
+    pub event_id: String,
+    pub schema: String,
+}
+
+impl WebhookEvent {
+    pub fn new_status_set(
+        user_did: String,
+        handle: String,
+        emoji: String,
+        text: Option<String>,
+        expires_at: Option<String>,
+        status_uri: String,
+    ) -> Self {
+        Self {
+            event_type: "status.set".to_string(),
+            user_did,
+            handle,
+            emoji,
+            text,
+            expires_at,
+            status_uri,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            event_id: Uuid::new_v4().to_string(),
+            schema: "status-webhook.v1".to_string(),
+        }
+    }
+
+    pub fn new_status_cleared(
+        user_did: String,
+        handle: String,
+        status_uri: String,
+    ) -> Self {
+        Self {
+            event_type: "status.cleared".to_string(),
+            user_did,
+            handle,
+            emoji: String::new(),
+            text: None,
+            expires_at: None,
+            status_uri,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            event_id: Uuid::new_v4().to_string(),
+            schema: "status-webhook.v1".to_string(),
+        }
+    }
+}
+
+/// Generate HMAC signature for webhook payload
+pub fn generate_signature(secret: &str, timestamp: i64, payload: &str) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC can take key of any size");
+    let message = format!("v0:{}:{}", timestamp, payload);
+    mac.update(message.as_bytes());
+    let result = mac.finalize();
+    format!("v1={}", hex::encode(result.into_bytes()))
+}
+
+/// Verify webhook signature
+pub fn verify_signature(secret: &str, timestamp: i64, payload: &str, signature: &str) -> bool {
+    if !signature.starts_with("v1=") {
+        return false;
+    }
+    
+    let expected_signature = generate_signature(secret, timestamp, payload);
+    signature == expected_signature
+}
+
+/// Get webhook configuration for authenticated user
+#[get("/api/webhook/config")]
+pub async fn get_webhook_config(
+    session: Session,
+    db_pool: web::Data<Arc<Pool>>,
+) -> Result<HttpResponse> {
+    let user_did = match session.get::<String>("did").unwrap_or(None) {
+        Some(did) => did,
+        None => {
+            return Ok(HttpResponse::Unauthorized().json(serde_json::json!({
+                "error": "Not authenticated"
+            })));
+        }
+    };
+
+    match WebhookConfig::get_by_user_did(&db_pool, &user_did).await {
+        Ok(Some(config)) => {
+            let response = WebhookConfigResponse {
+                id: config.id.unwrap_or(0),
+                webhook_url: config.webhook_url,
+                webhook_secret: config.webhook_secret,
+                enabled: config.enabled,
+                last_delivery_at: config.last_delivery_at,
+                created_at: config.created_at,
+                updated_at: config.updated_at,
+            };
+            Ok(HttpResponse::Ok().json(response))
+        }
+        Ok(None) => Ok(HttpResponse::NotFound().json(serde_json::json!({
+            "error": "Webhook not configured"
+        }))),
+        Err(err) => {
+            log::error!("Failed to get webhook config: {}", err);
+            Ok(HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": "Database error"
+            })))
+        }
+    }
+}
+
+/// Configure or update webhook for authenticated user
+#[post("/api/webhook/config")]
+pub async fn configure_webhook(
+    session: Session,
+    db_pool: web::Data<Arc<Pool>>,
+    req: web::Json<WebhookConfigRequest>,
+) -> Result<HttpResponse> {
+    let user_did = match session.get::<String>("did").unwrap_or(None) {
+        Some(did) => did,
+        None => {
+            return Ok(HttpResponse::Unauthorized().json(serde_json::json!({
+                "error": "Not authenticated"
+            })));
+        }
+    };
+
+    // Validate webhook URL
+    if !req.webhook_url.starts_with("https://") {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "Webhook URL must use HTTPS"
+        })));
+    }
+
+    // Generate secret if not provided
+    let webhook_secret = match &req.webhook_secret {
+        Some(secret) => secret.clone(),
+        None => {
+            // Generate a secure random secret
+            use rand::Rng;
+            let mut rng = rand::thread_rng();
+            let secret_bytes: [u8; 32] = rng.gen();
+            hex::encode(secret_bytes)
+        }
+    };
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let mut config = WebhookConfig::new(user_did, req.webhook_url.clone(), webhook_secret);
+    config.updated_at = now;
+
+    match config.save_or_update(&db_pool).await {
+        Ok(config_id) => {
+            config.id = Some(config_id);
+            let response = WebhookConfigResponse {
+                id: config_id,
+                webhook_url: config.webhook_url,
+                webhook_secret: config.webhook_secret,
+                enabled: config.enabled,
+                last_delivery_at: config.last_delivery_at,
+                created_at: config.created_at,
+                updated_at: config.updated_at,
+            };
+            Ok(HttpResponse::Ok().json(response))
+        }
+        Err(err) => {
+            log::error!("Failed to save webhook config: {}", err);
+            Ok(HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": "Failed to save webhook configuration"
+            })))
+        }
+    }
+}
+
+/// Test webhook delivery
+#[post("/api/webhook/test")]
+pub async fn test_webhook(
+    session: Session,
+    db_pool: web::Data<Arc<Pool>>,
+    req: web::Json<WebhookTestRequest>,
+) -> Result<HttpResponse> {
+    let user_did = match session.get::<String>("did").unwrap_or(None) {
+        Some(did) => did,
+        None => {
+            return Ok(HttpResponse::Unauthorized().json(serde_json::json!({
+                "error": "Not authenticated"
+            })));
+        }
+    };
+
+    // Create a test event
+    let test_event = WebhookEvent::new_status_set(
+        user_did.clone(),
+        "test.example.com".to_string(),
+        "🧪".to_string(),
+        Some("This is a test webhook delivery".to_string()),
+        None,
+        format!("at://{}/io.zzstoatzz.status.record/test", user_did),
+    );
+
+    let payload = serde_json::to_string(&test_event).map_err(|e| {
+        log::error!("Failed to serialize test event: {}", e);
+        actix_web::error::ErrorInternalServerError("Serialization error")
+    })?;
+
+    // Try to deliver the webhook
+    let result = deliver_webhook_event(&req.webhook_url, &req.webhook_secret, &payload).await;
+
+    match result {
+        Ok((status, response_body)) => {
+            Ok(HttpResponse::Ok().json(serde_json::json!({
+                "success": true,
+                "status_code": status,
+                "response": response_body,
+                "message": "Test webhook delivered successfully"
+            })))
+        }
+        Err(err) => {
+            log::warn!("Test webhook delivery failed: {}", err);
+            Ok(HttpResponse::BadRequest().json(serde_json::json!({
+                "success": false,
+                "error": format!("Webhook delivery failed: {}", err),
+                "message": "Test webhook delivery failed"
+            })))
+        }
+    }
+}
+
+/// Get recent webhook deliveries
+#[get("/api/webhook/deliveries")]
+pub async fn get_webhook_deliveries(
+    session: Session,
+    db_pool: web::Data<Arc<Pool>>,
+) -> Result<HttpResponse> {
+    let user_did = match session.get::<String>("did").unwrap_or(None) {
+        Some(did) => did,
+        None => {
+            return Ok(HttpResponse::Unauthorized().json(serde_json::json!({
+                "error": "Not authenticated"
+            })));
+        }
+    };
+
+    // First get the webhook config to get the config_id
+    match WebhookConfig::get_by_user_did(&db_pool, &user_did).await {
+        Ok(Some(config)) => {
+            let config_id = config.id.unwrap_or(0);
+            match WebhookDelivery::get_recent_deliveries(&db_pool, config_id, 20).await {
+                Ok(deliveries) => Ok(HttpResponse::Ok().json(deliveries)),
+                Err(err) => {
+                    log::error!("Failed to get webhook deliveries: {}", err);
+                    Ok(HttpResponse::InternalServerError().json(serde_json::json!({
+                        "error": "Failed to get delivery history"
+                    })))
+                }
+            }
+        }
+        Ok(None) => Ok(HttpResponse::NotFound().json(serde_json::json!({
+            "error": "Webhook not configured"
+        }))),
+        Err(err) => {
+            log::error!("Failed to get webhook config: {}", err);
+            Ok(HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": "Database error"
+            })))
+        }
+    }
+}
+
+/// Delete webhook configuration
+#[post("/api/webhook/delete")]
+pub async fn delete_webhook(
+    session: Session,
+    db_pool: web::Data<Arc<Pool>>,
+) -> Result<HttpResponse> {
+    let user_did = match session.get::<String>("did").unwrap_or(None) {
+        Some(did) => did,
+        None => {
+            return Ok(HttpResponse::Unauthorized().json(serde_json::json!({
+                "error": "Not authenticated"
+            })));
+        }
+    };
+
+    match WebhookConfig::delete_by_user_did(&db_pool, &user_did).await {
+        Ok(()) => Ok(HttpResponse::Ok().json(serde_json::json!({
+            "success": true,
+            "message": "Webhook configuration deleted"
+        }))),
+        Err(err) => {
+            log::error!("Failed to delete webhook config: {}", err);
+            Ok(HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": "Failed to delete webhook configuration"
+            })))
+        }
+    }
+}
+
+/// Deliver a webhook event via HTTP POST
+pub async fn deliver_webhook_event(
+    webhook_url: &str,
+    webhook_secret: &str,
+    payload: &str,
+) -> Result<(u16, String), reqwest::Error> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let signature = generate_signature(webhook_secret, timestamp, payload);
+    let event_id = Uuid::new_v4().to_string();
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(webhook_url)
+        .header("Content-Type", "application/json")
+        .header("User-Agent", "Status-Webhook/1.0")
+        .header("X-Status-Timestamp", timestamp.to_string())
+        .header("X-Status-Event-Id", &event_id)
+        .header("X-Status-Signature", &signature)
+        .header("Idempotency-Key", &event_id)
+        .body(payload.to_string())
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await?;
+
+    let status = response.status().as_u16();
+    let body = response.text().await.unwrap_or_default();
+
+    Ok((status, body))
+}
+
+/// Send webhook event for status changes (called from status operations)
+pub async fn emit_webhook_event(
+    db_pool: &Pool,
+    user_did: &str,
+    event: &WebhookEvent,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Get webhook config for the user
+    if let Some(config) = WebhookConfig::get_by_user_did(db_pool, user_did).await? {
+        if !config.enabled {
+            log::debug!("Webhook disabled for user {}", user_did);
+            return Ok(());
+        }
+
+        let config_id = config.id.unwrap_or(0);
+        let payload = serde_json::to_string(event)?;
+
+        // Create delivery record
+        let mut delivery = WebhookDelivery::new(
+            config_id,
+            event.event_id.clone(),
+            event.event_type.clone(),
+            payload.clone(),
+        );
+
+        let delivery_id = delivery.save(db_pool).await?;
+        delivery.id = Some(delivery_id);
+
+        // Try to deliver
+        match deliver_webhook_event(&config.webhook_url, &config.webhook_secret, &payload).await {
+            Ok((status, response_body)) => {
+                let success = status >= 200 && status < 300;
+                delivery.update_result(db_pool, status as i32, Some(response_body), success).await?;
+                
+                // Update last delivery time on config
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs() as i64;
+                config.update_last_delivery(db_pool, now).await?;
+
+                if success {
+                    log::debug!("Webhook delivered successfully for user {} (status: {})", user_did, status);
+                } else {
+                    log::warn!("Webhook delivery failed for user {} (status: {})", user_did, status);
+                }
+            }
+            Err(err) => {
+                log::error!("Webhook delivery failed for user {}: {}", user_did, err);
+                delivery.update_result(db_pool, 0, Some(err.to_string()), false).await?;
+                
+                // TODO: Implement retry logic here
+                // For now, we just log the failure
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,6 +1,6 @@
 ///The askama template types for HTML
 ///
-use crate::db::StatusFromDb;
+use crate::db::{StatusFromDb, WebhookConfig};
 use askama::Template;
 use serde::{Deserialize, Serialize};
 
@@ -48,4 +48,13 @@ pub struct FeedTemplate<'a> {
     pub statuses: Vec<StatusFromDb>,
     pub is_admin: bool,
     pub dev_mode: bool,
+}
+
+#[derive(Template)]
+#[template(path = "webhook_settings.html")]
+pub struct WebhookSettingsTemplate<'a> {
+    #[allow(dead_code)]
+    pub title: &'a str,
+    pub handle: String,
+    pub webhook_config: Option<WebhookConfig>,
 }

--- a/templates/webhook_settings.html
+++ b/templates/webhook_settings.html
@@ -1,0 +1,763 @@
+{% extends "base.html" %}
+
+{% block title %}Webhook Settings - @{{ handle }}{% endblock %}
+
+{% block content %}
+<div id="root">
+    <div class="container">
+        <!-- Header -->
+        <header class="header">
+            <h1><a href="/" class="handle-link">@{{ handle }}</a> - Webhook Settings</h1>
+            <div class="header-actions">
+                <a href="/" class="nav-button" aria-label="Back to status" title="Back to status">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M19 12H5M12 19l-7-7 7-7"/>
+                    </svg>
+                </a>
+            </div>
+        </header>
+
+        <!-- Webhook Configuration -->
+        <div class="webhook-section">
+            <h2>Slack Integration via Webhooks</h2>
+            <p class="webhook-description">
+                Configure a webhook to receive real-time notifications when your status changes. 
+                This is perfect for integrating with Slack, Discord, or custom automation systems.
+            </p>
+
+            {% if let Some(config) = webhook_config %}
+            <!-- Existing Configuration -->
+            <div class="webhook-config">
+                <div class="config-item">
+                    <label>Webhook URL</label>
+                    <div class="url-display">
+                        <code>{{ config.webhook_url }}</code>
+                        <button type="button" class="copy-btn" data-copy="{{ config.webhook_url }}">Copy</button>
+                    </div>
+                </div>
+                
+                <div class="config-item">
+                    <label>Webhook Secret</label>
+                    <div class="secret-display">
+                        <code class="secret-value" id="secret-value">{{ config.webhook_secret }}</code>
+                        <button type="button" class="toggle-secret" id="toggle-secret">Show</button>
+                        <button type="button" class="copy-btn" data-copy="{{ config.webhook_secret }}">Copy</button>
+                    </div>
+                </div>
+                
+                <div class="config-item">
+                    <label>Status</label>
+                    <div class="status-display">
+                        <span class="status-indicator {% if config.enabled %}enabled{% else %}disabled{% endif %}">
+                            {% if config.enabled %}Enabled{% else %}Disabled{% endif %}
+                        </span>
+                        {% if config.last_delivery_at.is_some() %}
+                        <span class="last-delivery">
+                            Last delivery: <span class="local-time" data-timestamp="{{ config.last_delivery_at.unwrap() }}" data-format="relative"></span>
+                        </span>
+                        {% endif %}
+                    </div>
+                </div>
+                
+                <div class="config-actions">
+                    <button type="button" class="test-btn" id="test-webhook">Test Webhook</button>
+                    <button type="button" class="edit-btn" id="edit-webhook">Edit</button>
+                    <button type="button" class="delete-btn" id="delete-webhook">Delete</button>
+                </div>
+            </div>
+            
+            <div class="webhook-deliveries">
+                <h3>Recent Deliveries</h3>
+                <div class="deliveries-list" id="deliveries-list">
+                    <!-- Will be populated by JavaScript -->
+                </div>
+            </div>
+            {% else %}
+            <!-- Configuration Form -->
+            <div class="webhook-form" id="webhook-form">
+                <form id="webhook-config-form">
+                    <div class="form-group">
+                        <label for="webhook-url">Webhook URL</label>
+                        <input type="url" id="webhook-url" name="webhook_url" 
+                               placeholder="https://your-server.com/webhook" 
+                               required>
+                        <small>Must use HTTPS. This URL will receive POST requests when your status changes.</small>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label for="webhook-secret">Secret (optional)</label>
+                        <input type="text" id="webhook-secret" name="webhook_secret" 
+                               placeholder="Leave empty to auto-generate">
+                        <small>Used to sign webhook requests. If empty, we'll generate a secure secret for you.</small>
+                    </div>
+                    
+                    <div class="form-actions">
+                        <button type="submit" class="save-btn">Save Webhook</button>
+                        <button type="button" class="cancel-btn" onclick="window.location.href='/'">Cancel</button>
+                    </div>
+                </form>
+            </div>
+            {% endif %}
+        </div>
+        
+        <!-- Edit Form (initially hidden) -->
+        <div class="webhook-edit-form hidden" id="webhook-edit-form">
+            <h3>Edit Webhook Configuration</h3>
+            <form id="webhook-edit-config-form">
+                <div class="form-group">
+                    <label for="edit-webhook-url">Webhook URL</label>
+                    <input type="url" id="edit-webhook-url" name="webhook_url" 
+                           value="{% if let Some(config) = webhook_config %}{{ config.webhook_url }}{% endif %}" 
+                           required>
+                </div>
+                
+                <div class="form-group">
+                    <label for="edit-webhook-secret">Secret</label>
+                    <input type="text" id="edit-webhook-secret" name="webhook_secret" 
+                           value="{% if let Some(config) = webhook_config %}{{ config.webhook_secret }}{% endif %}" 
+                           placeholder="Leave empty to generate new secret">
+                    <small>Changing this will invalidate the current secret.</small>
+                </div>
+                
+                <div class="form-actions">
+                    <button type="submit" class="save-btn">Update Webhook</button>
+                    <button type="button" class="cancel-btn" id="cancel-edit">Cancel</button>
+                </div>
+            </form>
+        </div>
+
+        <!-- Documentation -->
+        <div class="webhook-docs">
+            <h3>Webhook Documentation</h3>
+            
+            <div class="doc-section">
+                <h4>Event Types</h4>
+                <ul>
+                    <li><code>status.set</code> - When a new status is created or updated</li>
+                    <li><code>status.cleared</code> - When a status is deleted or cleared</li>
+                </ul>
+            </div>
+            
+            <div class="doc-section">
+                <h4>Payload Example</h4>
+                <pre><code>{
+  "type": "status.set",
+  "user_did": "did:plc:example...",
+  "handle": "alice.bsky.social",
+  "emoji": "🚀",
+  "text": "Working on something cool",
+  "expires_at": "2025-01-10T15:30:00Z",
+  "status_uri": "at://did:plc:.../io.zzstoatzz.status.record/abc123",
+  "timestamp": "2025-01-10T14:30:00Z",
+  "event_id": "uuid-here",
+  "schema": "status-webhook.v1"
+}</code></pre>
+            </div>
+            
+            <div class="doc-section">
+                <h4>Security</h4>
+                <p>All webhook requests include these headers for verification:</p>
+                <ul>
+                    <li><code>X-Status-Timestamp</code> - Unix timestamp when request was sent</li>
+                    <li><code>X-Status-Event-Id</code> - Unique ID for this event (use for idempotency)</li>
+                    <li><code>X-Status-Signature</code> - HMAC-SHA256 signature: <code>v1=hex(hmac_sha256(secret, "v0:{timestamp}:{body}"))</code></li>
+                    <li><code>Idempotency-Key</code> - Same as Event ID</li>
+                </ul>
+            </div>
+            
+            <div class="doc-section">
+                <h4>Sample Handler (Node.js)</h4>
+                <pre><code>const crypto = require('crypto');
+
+app.post('/webhook', (req, res) => {
+  const signature = req.headers['x-status-signature'];
+  const timestamp = req.headers['x-status-timestamp'];
+  const body = JSON.stringify(req.body);
+  
+  // Verify signature
+  const expectedSig = `v1=${crypto
+    .createHmac('sha256', process.env.WEBHOOK_SECRET)
+    .update(`v0:${timestamp}:${body}`)
+    .digest('hex')}`;
+    
+  if (signature !== expectedSig) {
+    return res.status(401).send('Invalid signature');
+  }
+  
+  // Check timestamp (reject old requests)
+  if (Math.abs(Date.now() / 1000 - parseInt(timestamp)) > 300) {
+    return res.status(401).send('Request too old');
+  }
+  
+  // Process the event
+  console.log('Status event:', req.body);
+  res.status(200).send('OK');
+});</code></pre>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+.webhook-section {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius);
+    padding: 2rem;
+    margin-bottom: 2rem;
+}
+
+.webhook-description {
+    color: var(--text-secondary);
+    margin-bottom: 2rem;
+    line-height: 1.6;
+}
+
+.webhook-config {
+    margin-bottom: 2rem;
+}
+
+.config-item {
+    margin-bottom: 1.5rem;
+}
+
+.config-item label {
+    display: block;
+    color: var(--text-secondary);
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+}
+
+.url-display, .secret-display {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.url-display code, .secret-display code {
+    flex: 1;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    padding: 0.5rem 0.75rem;
+    font-family: monospace;
+    color: var(--text-primary);
+    overflow-wrap: break-word;
+    word-break: break-all;
+}
+
+.secret-value.hidden {
+    filter: blur(4px);
+    user-select: none;
+}
+
+.copy-btn, .toggle-secret {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.copy-btn:hover, .toggle-secret:hover {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+}
+
+.status-display {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.status-indicator {
+    padding: 0.25rem 0.75rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+.status-indicator.enabled {
+    background: rgba(34, 197, 94, 0.1);
+    color: rgb(34, 197, 94);
+}
+
+.status-indicator.disabled {
+    background: rgba(239, 68, 68, 0.1);
+    color: rgb(239, 68, 68);
+}
+
+.last-delivery {
+    color: var(--text-tertiary);
+    font-size: 0.875rem;
+}
+
+.config-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 2rem;
+}
+
+.test-btn, .edit-btn, .delete-btn {
+    padding: 0.5rem 1rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.test-btn {
+    background: var(--accent);
+    color: white;
+    border: none;
+}
+
+.test-btn:hover {
+    background: var(--accent-hover);
+}
+
+.edit-btn {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+}
+
+.edit-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.delete-btn {
+    background: transparent;
+    border: 1px solid var(--danger);
+    color: var(--danger);
+}
+
+.delete-btn:hover {
+    background: var(--danger);
+    color: white;
+}
+
+.webhook-form, .webhook-edit-form {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius);
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.webhook-edit-form.hidden {
+    display: none;
+}
+
+.form-group {
+    margin-bottom: 1.5rem;
+}
+
+.form-group label {
+    display: block;
+    color: var(--text-primary);
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+}
+
+.form-group input {
+    width: 100%;
+    padding: 0.75rem;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-size: 1rem;
+}
+
+.form-group input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(74, 158, 255, 0.1);
+}
+
+.form-group small {
+    display: block;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+}
+
+.form-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 2rem;
+}
+
+.save-btn, .cancel-btn {
+    padding: 0.75rem 1.5rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.save-btn {
+    background: var(--accent);
+    color: white;
+    border: none;
+}
+
+.save-btn:hover {
+    background: var(--accent-hover);
+}
+
+.cancel-btn {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+}
+
+.cancel-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.webhook-deliveries {
+    margin-top: 2rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--border-color);
+}
+
+.webhook-deliveries h3 {
+    margin-bottom: 1rem;
+    color: var(--text-primary);
+}
+
+.delivery-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    margin-bottom: 0.5rem;
+}
+
+.delivery-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.delivery-event {
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.delivery-time {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+.delivery-status {
+    padding: 0.25rem 0.5rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.delivery-status.success {
+    background: rgba(34, 197, 94, 0.1);
+    color: rgb(34, 197, 94);
+}
+
+.delivery-status.failed {
+    background: rgba(239, 68, 68, 0.1);
+    color: rgb(239, 68, 68);
+}
+
+.webhook-docs {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius);
+    padding: 2rem;
+}
+
+.webhook-docs h3 {
+    margin-bottom: 1.5rem;
+    color: var(--text-primary);
+}
+
+.doc-section {
+    margin-bottom: 2rem;
+}
+
+.doc-section h4 {
+    margin-bottom: 1rem;
+    color: var(--text-primary);
+    font-size: 1.1rem;
+}
+
+.doc-section ul {
+    margin-left: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.doc-section li {
+    margin-bottom: 0.5rem;
+    color: var(--text-secondary);
+}
+
+.doc-section code {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    padding: 0.125rem 0.375rem;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 0.875rem;
+}
+
+.doc-section pre {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    padding: 1rem;
+    overflow-x: auto;
+    margin: 1rem 0;
+}
+
+.doc-section pre code {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 0.875rem;
+    line-height: 1.4;
+}
+
+/* Mobile adjustments */
+@media (max-width: 640px) {
+    .config-actions, .form-actions {
+        flex-direction: column;
+    }
+    
+    .url-display, .secret-display {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.5rem;
+    }
+    
+    .delivery-item {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+}
+
+.hidden {
+    display: none !important;
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', async () => {
+    // Copy to clipboard functionality
+    document.querySelectorAll('.copy-btn').forEach(btn => {
+        btn.addEventListener('click', async () => {
+            const text = btn.getAttribute('data-copy');
+            try {
+                await navigator.clipboard.writeText(text);
+                const originalText = btn.textContent;
+                btn.textContent = 'Copied!';
+                setTimeout(() => {
+                    btn.textContent = originalText;
+                }, 2000);
+            } catch (err) {
+                console.error('Failed to copy:', err);
+            }
+        });
+    });
+
+    // Toggle secret visibility
+    const toggleSecret = document.getElementById('toggle-secret');
+    const secretValue = document.getElementById('secret-value');
+    if (toggleSecret && secretValue) {
+        secretValue.classList.add('hidden');
+        toggleSecret.addEventListener('click', () => {
+            secretValue.classList.toggle('hidden');
+            toggleSecret.textContent = secretValue.classList.contains('hidden') ? 'Show' : 'Hide';
+        });
+    }
+
+    // Load webhook deliveries if webhook exists
+    {% if webhook_config.is_some() %}
+    loadWebhookDeliveries();
+    {% endif %}
+
+    // Test webhook functionality
+    const testBtn = document.getElementById('test-webhook');
+    if (testBtn) {
+        testBtn.addEventListener('click', async () => {
+            testBtn.disabled = true;
+            testBtn.textContent = 'Testing...';
+            
+            const webhookUrl = '{{ webhook_config.as_ref().map(|c| c.webhook_url.clone()).unwrap_or_default() }}';
+            const webhookSecret = '{{ webhook_config.as_ref().map(|c| c.webhook_secret.clone()).unwrap_or_default() }}';
+            
+            try {
+                const response = await fetch('/api/webhook/test', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        webhook_url: webhookUrl,
+                        webhook_secret: webhookSecret
+                    })
+                });
+                
+                const result = await response.json();
+                
+                if (result.success) {
+                    alert(`Test successful! Status: ${result.status_code}`);
+                    loadWebhookDeliveries(); // Refresh delivery list
+                } else {
+                    alert(`Test failed: ${result.error}`);
+                }
+            } catch (err) {
+                alert(`Test failed: ${err.message}`);
+            }
+            
+            testBtn.disabled = false;
+            testBtn.textContent = 'Test Webhook';
+        });
+    }
+
+    // Edit webhook functionality
+    const editBtn = document.getElementById('edit-webhook');
+    const editForm = document.getElementById('webhook-edit-form');
+    const cancelEditBtn = document.getElementById('cancel-edit');
+    
+    if (editBtn && editForm) {
+        editBtn.addEventListener('click', () => {
+            editForm.classList.remove('hidden');
+        });
+    }
+    
+    if (cancelEditBtn && editForm) {
+        cancelEditBtn.addEventListener('click', () => {
+            editForm.classList.add('hidden');
+        });
+    }
+
+    // Delete webhook functionality
+    const deleteBtn = document.getElementById('delete-webhook');
+    if (deleteBtn) {
+        deleteBtn.addEventListener('click', async () => {
+            if (confirm('Are you sure you want to delete this webhook configuration? This cannot be undone.')) {
+                try {
+                    const response = await fetch('/api/webhook/delete', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        }
+                    });
+                    
+                    const result = await response.json();
+                    
+                    if (result.success) {
+                        window.location.reload(); // Refresh page to show form
+                    } else {
+                        alert('Failed to delete webhook configuration');
+                    }
+                } catch (err) {
+                    alert(`Failed to delete: ${err.message}`);
+                }
+            }
+        });
+    }
+
+    // Form submissions
+    const configForm = document.getElementById('webhook-config-form');
+    const editConfigForm = document.getElementById('webhook-edit-config-form');
+    
+    if (configForm) {
+        configForm.addEventListener('submit', handleWebhookSubmit);
+    }
+    
+    if (editConfigForm) {
+        editConfigForm.addEventListener('submit', handleWebhookSubmit);
+    }
+
+    async function handleWebhookSubmit(e) {
+        e.preventDefault();
+        
+        const formData = new FormData(e.target);
+        const data = {
+            webhook_url: formData.get('webhook_url'),
+            webhook_secret: formData.get('webhook_secret') || undefined
+        };
+        
+        const submitBtn = e.target.querySelector('button[type="submit"]');
+        submitBtn.disabled = true;
+        submitBtn.textContent = 'Saving...';
+        
+        try {
+            const response = await fetch('/api/webhook/config', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(data)
+            });
+            
+            const result = await response.json();
+            
+            if (response.ok) {
+                window.location.reload(); // Refresh to show the saved config
+            } else {
+                alert(`Failed to save: ${result.error}`);
+            }
+        } catch (err) {
+            alert(`Failed to save: ${err.message}`);
+        }
+        
+        submitBtn.disabled = false;
+        submitBtn.textContent = e.target.id === 'webhook-edit-config-form' ? 'Update Webhook' : 'Save Webhook';
+    }
+
+    async function loadWebhookDeliveries() {
+        try {
+            const response = await fetch('/api/webhook/deliveries');
+            const deliveries = await response.json();
+            
+            const deliveriesList = document.getElementById('deliveries-list');
+            if (!deliveriesList) return;
+            
+            if (deliveries.length === 0) {
+                deliveriesList.innerHTML = '<p style="color: var(--text-secondary); text-align: center; padding: 2rem;">No deliveries yet</p>';
+                return;
+            }
+            
+            deliveriesList.innerHTML = deliveries.map(delivery => {
+                const timestamp = new Date(delivery.delivered_at * 1000).toLocaleString();
+                const statusClass = delivery.success ? 'success' : 'failed';
+                const statusText = delivery.success ? 'Success' : 'Failed';
+                
+                return `
+                    <div class="delivery-item">
+                        <div class="delivery-info">
+                            <div class="delivery-event">${delivery.event_type}</div>
+                            <div class="delivery-time">${timestamp}</div>
+                        </div>
+                        <div class="delivery-status ${statusClass}">${statusText}</div>
+                    </div>
+                `;
+            }).join('');
+        } catch (err) {
+            console.error('Failed to load deliveries:', err);
+        }
+    }
+});
+</script>
+{% endblock content %}


### PR DESCRIPTION
This PR implements the webhook-based approach for Slack status synchronization as described in issue #24. Instead of storing Slack OAuth tokens, this solution emits signed webhooks that users can route to their own handlers, providing a secure and flexible integration path.

Generated with [Claude Code](https://claude.ai/code)