### PR TITLE
hotfix/feed shape

### DIFF
--- a/templates/feed.html
+++ b/templates/feed.html
@@ -122,8 +122,8 @@
                 {% endif %}
             </div>
             
-            {% if !statuses.is_empty() %}
             <div class="status-list">
+            {% if !statuses.is_empty() %}
                 {% for status in statuses %}
                 <div class="status-item" data-did="{{ status.author_did }}">
                     <span class="status-emoji">
@@ -158,13 +158,10 @@
                     </div>
                 </div>
                 {% endfor %}
-            </div>
             {% else %}
-            <div class="empty-state">
-                <span class="empty-emoji">💭</span>
-                <p>no status updates yet</p>
-            </div>
+                <!-- empty at render; JS will populate via /api/feed -->
             {% endif %}
+            </div>
             
             <!-- Loading indicator -->
             <div id="loading-indicator" style="display: none; text-align: center; padding: 2rem;">


### PR DESCRIPTION
- **feed(ui): always fetch first page on DOMContentLoaded so global feed never renders empty**
- **feed(ui): always render an empty .status-list container so JS can append results when server has no initial statuses**
