### PR TITLE
Add GitHub footer with link to source repository

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -116,10 +116,64 @@
                 height: 20px;
             }
         }
+        /* GitHub Footer Styles */
+        .github-footer {
+            position: fixed;
+            bottom: 20px;
+            left: 20px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 14px;
+            color: var(--text-tertiary, #6c757d);
+            text-decoration: none;
+            transition: all 0.3s ease;
+            z-index: 9998;
+        }
+        
+        .github-footer:hover {
+            color: var(--accent, #1DA1F2);
+        }
+        
+        .github-footer svg {
+            width: 20px;
+            height: 20px;
+            fill: currentColor;
+            transition: transform 0.3s ease;
+        }
+        
+        .github-footer:hover svg {
+            transform: scale(1.1);
+        }
+        
+        @media (max-width: 640px) {
+            .github-footer {
+                bottom: 15px;
+                left: 15px;
+                font-size: 12px;
+            }
+            
+            .github-footer svg {
+                width: 18px;
+                height: 18px;
+            }
+            
+            .github-footer span {
+                display: none;
+            }
+        }
     </style>
 </head>
 <body>
     {% block content %}{% endblock %}
+    
+    <!-- GitHub Footer -->
+    <a href="https://github.com/zzstoatzz/status" class="github-footer" target="_blank" rel="noopener noreferrer" aria-label="View source on GitHub">
+        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+        </svg>
+        <span>zzstoatzz/status</span>
+    </a>
     
     <!-- Bug Report Button -->
     <button class="bug-report-button" id="bug-report-button" aria-label="Report a bug">


### PR DESCRIPTION
Fixes #54

## Summary
Added a GitHub footer link to all pages that points to the source repository.

## Changes
- Added fixed position GitHub icon and link in bottom-left corner
- Styled to match existing site theme using CSS variables
- Appears on all pages via base.html template
- Responsive design hides text on mobile, keeping only icon
- Positioned opposite to bug report button for visual balance

Generated with [Claude Code](https://claude.ai/code)