### PR TITLE
fix: Allow emoji-only status changes without text

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -2045,6 +2045,7 @@ let emojiData = {
                     
                     statusInput.value = emoji;
                     emojiPicker.style.display = 'none';
+                    checkForChanges();
                 });
             });
         } else if (category === 'custom') {
@@ -2071,6 +2072,7 @@ let emojiData = {
                     selectedEmoji.innerHTML = `<img src="${img.src}" alt="${img.alt}" style="width: 100%; height: 100%; object-fit: contain;">`;
                     statusInput.value = emojiValue;
                     emojiPicker.style.display = 'none';
+                    checkForChanges();
                 });
             });
         } else {
@@ -2088,6 +2090,7 @@ let emojiData = {
                     selectedEmoji.textContent = emoji;
                     statusInput.value = emoji;
                     emojiPicker.style.display = 'none';
+                    checkForChanges();
                 });
             });
         }
@@ -2323,6 +2326,7 @@ let emojiData = {
                 
                 statusInput.value = emojiValue;
                 emojiPicker.style.display = 'none';
+                checkForChanges();
                 // Clear search when emoji is selected
                 document.getElementById('emoji-search').value = '';
             });
@@ -2360,7 +2364,13 @@ let emojiData = {
         const newText = statusText.value.trim();
         
         // Check if this is identical to current status
-        if (currentStatus.emoji === newEmoji && currentStatus.text === newText) {
+        // If there's no current status (emoji is null), allow any emoji selection as a change
+        const hasCurrentStatus = currentStatus.emoji !== null;
+        const isIdentical = hasCurrentStatus && 
+                           currentStatus.emoji === newEmoji && 
+                           currentStatus.text === newText;
+        
+        if (isIdentical) {
             saveBtn.disabled = true;
             saveBtn.textContent = 'No changes';
         } else {


### PR DESCRIPTION
Fixes #56 - Allow creating new status with only emoji changes

When creating a new status with only an emoji change (no text), the validation was incorrectly showing 'No changes'. 

## Changes
- Properly handle the case where there's no current status (emoji is null)
- Trigger validation after emoji selection from picker
- Only disable submission when the new status is identical to existing

Generated with [Claude Code](https://claude.ai/code)