### PR TITLE
Fix link hover colors to respect accent color preference

### DIFF
--- a/templates/error.html
+++ b/templates/error.html
@@ -53,7 +53,7 @@
     --text-tertiary: #adb5bd;
     --border-color: #e9ecef;
     --accent: #4a9eff;
-    --accent-hover: #3a8eee;
+    --accent-hover: color-mix(in srgb, var(--accent) 85%, black);
     --danger: #dc3545;
     --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
     --shadow-md: 0 4px 6px rgba(0,0,0,0.07);

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -197,7 +197,7 @@
     --text-tertiary: #adb5bd;
     --border-color: #e9ecef;
     --accent: #4a9eff;
-    --accent-hover: #3a8eee;
+    --accent-hover: color-mix(in srgb, var(--accent) 85%, black);
     --danger: #dc3545;
     --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
     --shadow-md: 0 4px 6px rgba(0,0,0,0.07);

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -662,7 +662,13 @@ body {
     transition: color 0.2s;
 }
 
-.status-author:hover {
+.status-author:link,
+.status-author:visited {
+    color: var(--text-secondary);
+}
+
+.status-author:hover,
+.status-author:active {
     color: var(--accent);
 }
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -86,7 +86,7 @@
     --text-tertiary: #adb5bd;
     --border-color: #e9ecef;
     --accent: #4a9eff;
-    --accent-hover: #3a8eee;
+    --accent-hover: color-mix(in srgb, var(--accent) 85%, black);
     --danger: #dc3545;
     --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
     --shadow-md: 0 4px 6px rgba(0,0,0,0.07);

--- a/templates/status.html
+++ b/templates/status.html
@@ -599,6 +599,11 @@ body {
     border-radius: var(--radius-sm);
 }
 
+.handle-link:link,
+.handle-link:visited {
+    color: var(--text-secondary);
+}
+
 .handle-link::before {
     content: '';
     position: absolute;
@@ -611,7 +616,8 @@ body {
     filter: blur(8px);
 }
 
-.handle-link:hover {
+.handle-link:hover,
+.handle-link:active {
     color: var(--accent);
     text-shadow: 0 0 12px var(--accent);
 }


### PR DESCRIPTION
## Summary
- Fixed issue where status author links and other links showed browser default blue on hover
- Now all links properly respect the user's chosen accent color

## Changes
- Added explicit `:link` and `:visited` pseudo-class selectors to maintain consistent colors
- Ensured `:hover` and `:active` states use `var(--accent)` for all link elements
- Applied fix to both feed.html and status.html templates

## Test Plan
- [x] Verify status author links in feed use accent color on hover
- [x] Verify handle link on status page uses accent color on hover
- [x] Test with different accent colors to ensure dynamic theming works
- [x] Pre-commit hooks pass (HTML syntax validation)