### PR TITLE
Fix OAuth login issues for self-hosted PDS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,15 @@ async fn main() -> std::io::Result<()> {
                     // Using granular scope for status records only
                     // This replaces TransitionGeneric with specific permissions
                     Scope::Unknown("repo:io.zzstoatzz.status.record".to_string()),
+                    // Need to read profiles for the feed page
+                    Scope::Unknown(
+                        "rpc:app.bsky.actor.getProfile?aud=did:web:api.bsky.app#bsky_appview"
+                            .to_string(),
+                    ),
+                    // Need to read following list for following feed
+                    Scope::Unknown(
+                        "rpc:app.bsky.graph.getFollows?aud=did:web:api.bsky.app".to_string(),
+                    ),
                 ]),
             },
             keys: None,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -16,8 +16,6 @@ use thiserror::Error;
 pub enum SqliteStoreError {
     #[error("Invalid session")]
     InvalidSession,
-    #[error("No session found")]
-    NoSessionFound,
     #[error("Database error: {0}")]
     DatabaseError(async_sqlite::Error),
 }
@@ -49,7 +47,7 @@ where
                     .map_err(|_| SqliteStoreError::InvalidSession)?;
                 Ok(Some(deserialized_session))
             }
-            Ok(None) => Err(SqliteStoreError::NoSessionFound),
+            Ok(None) => Ok(None),
             Err(db_error) => {
                 log::error!("Database error: {db_error}");
                 Err(SqliteStoreError::DatabaseError(db_error))
@@ -110,7 +108,7 @@ where
                     .map_err(|_| SqliteStoreError::InvalidSession)?;
                 Ok(Some(deserialized_state))
             }
-            Ok(None) => Err(SqliteStoreError::NoSessionFound),
+            Ok(None) => Ok(None),
             Err(db_error) => {
                 log::error!("Database error: {db_error}");
                 Err(SqliteStoreError::DatabaseError(db_error))


### PR DESCRIPTION
## Summary
- Fixed OAuth state storage to properly handle missing entries
- Added missing OAuth scopes to localhost configuration  
- Cleaned up unused error variant

## Problem
When using a self-hosted PDS, the OAuth login flow was failing with "The data you have submitted is invalid" error at the authorization step.

## Root Cause
1. The `SqliteStateStore` and `SqliteSessionStore` were returning errors instead of `Ok(None)` when no existing state/session was found, breaking the OAuth client's expectations
2. The localhost configuration was missing the profile and follows scopes that were being requested during login

## Solution
- Changed both storage implementations to return `Ok(None)` when no record exists (instead of an error)
- Added the missing scopes to the localhost OAuth configuration to match what's requested
- Removed the now-unused `NoSessionFound` error variant

## Testing
Tested locally with self-hosted PDS - OAuth flow now completes successfully.